### PR TITLE
Allow disabling of http logging interceptor based on connection settings

### DIFF
--- a/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
+++ b/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
@@ -51,7 +51,8 @@ public class HttpConnectionSettings {
     public HttpConnectionSettings(final SSLContext sslContext, final X509TrustManager trustManager,
         final Interceptor customInterceptor, final int readTimeoutSeconds,
         final int connectTimeoutSeconds, final boolean retryOnConnectionFailure) {
-      this(sslContext, trustManager, customInterceptor, readTimeoutSeconds, connectTimeoutSeconds, retryOnConnectionFailure, true);
+      this(sslContext, trustManager, customInterceptor, readTimeoutSeconds, connectTimeoutSeconds, 
+          retryOnConnectionFailure, false);
     }
 
     public HttpConnectionSettings(final SSLContext sslContext, final X509TrustManager trustManager,

--- a/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
+++ b/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
@@ -30,7 +30,7 @@ public class HttpConnectionSettings {
      */
     private final boolean retryOnConnectionFailure;
     /**
-     * Whether or not to enable a {@link HttpLoggingInterceptor} on the http client used, 
+     * Whether or not to enable a {@link HttpLoggingInterceptor} on the HTTP client used, 
      * logging the body of all requests at default log level.
      */
     private final boolean loggingInterceptorEnabled;
@@ -53,7 +53,7 @@ public class HttpConnectionSettings {
         final int connectTimeoutSeconds, final boolean retryOnConnectionFailure) {
       this(sslContext, trustManager, customInterceptor, readTimeoutSeconds, connectTimeoutSeconds, retryOnConnectionFailure, true);
     }
-    
+
     public HttpConnectionSettings(final SSLContext sslContext, final X509TrustManager trustManager,
         final Interceptor customInterceptor, final int readTimeoutSeconds,
         final int connectTimeoutSeconds, final boolean retryOnConnectionFailure, boolean includeLoggingInterceptor) {

--- a/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
+++ b/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
@@ -73,7 +73,7 @@ public class HttpConnectionSettings {
         this.readTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
         this.connectTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
         this.retryOnConnectionFailure = true;
-        this.loggingInterceptorEnabled = true;
+        this.loggingInterceptorEnabled = false;
     }
 
     public SSLContext getSslContext() {

--- a/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
+++ b/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
@@ -9,6 +9,7 @@ package com.bynder.sdk.model;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 import okhttp3.Interceptor;
+import okhttp3.logging.HttpLoggingInterceptor;
 
 /**
  * Configuration holder for HTTP connection related settings for the connection to Bynder.
@@ -29,6 +30,11 @@ public class HttpConnectionSettings {
      */
     private final boolean retryOnConnectionFailure;
     /**
+     * Whether or not to enable a {@link HttpLoggingInterceptor} on the http client used, 
+     * logging the body of all requests at default log level.
+     */
+    private final boolean loggingInterceptorEnabled;
+    /**
      * SSL Context: allows to send a client SSL certificate. Can only be used if the trustManager
      * was defined.
      */
@@ -41,16 +47,23 @@ public class HttpConnectionSettings {
      * Custom OkHttp Interceptor: can be used to transform URLs to an ESB.
      */
     private Interceptor customInterceptor;
-
+    
     public HttpConnectionSettings(final SSLContext sslContext, final X509TrustManager trustManager,
         final Interceptor customInterceptor, final int readTimeoutSeconds,
         final int connectTimeoutSeconds, final boolean retryOnConnectionFailure) {
+      this(sslContext, trustManager, customInterceptor, readTimeoutSeconds, connectTimeoutSeconds, retryOnConnectionFailure, true);
+    }
+    
+    public HttpConnectionSettings(final SSLContext sslContext, final X509TrustManager trustManager,
+        final Interceptor customInterceptor, final int readTimeoutSeconds,
+        final int connectTimeoutSeconds, final boolean retryOnConnectionFailure, boolean includeLoggingInterceptor) {
         this.sslContext = sslContext;
         this.trustManager = trustManager;
         this.customInterceptor = customInterceptor;
         this.readTimeoutSeconds = readTimeoutSeconds;
         this.connectTimeoutSeconds = connectTimeoutSeconds;
         this.retryOnConnectionFailure = retryOnConnectionFailure;
+        this.loggingInterceptorEnabled = includeLoggingInterceptor;
     }
 
     /**
@@ -60,6 +73,7 @@ public class HttpConnectionSettings {
         this.readTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
         this.connectTimeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
         this.retryOnConnectionFailure = true;
+        this.loggingInterceptorEnabled = true;
     }
 
     public SSLContext getSslContext() {
@@ -85,4 +99,9 @@ public class HttpConnectionSettings {
     public boolean isRetryOnConnectionFailure() {
         return retryOnConnectionFailure;
     }
+    
+    public boolean isLoggingInterceptorEnabled() {
+        return loggingInterceptorEnabled;
+    }
+    
 }

--- a/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
+++ b/src/main/java/com/bynder/sdk/model/HttpConnectionSettings.java
@@ -47,7 +47,7 @@ public class HttpConnectionSettings {
      * Custom OkHttp Interceptor: can be used to transform URLs to an ESB.
      */
     private Interceptor customInterceptor;
-    
+
     public HttpConnectionSettings(final SSLContext sslContext, final X509TrustManager trustManager,
         final Interceptor customInterceptor, final int readTimeoutSeconds,
         final int connectTimeoutSeconds, final boolean retryOnConnectionFailure) {

--- a/src/main/java/com/bynder/sdk/util/Utils.java
+++ b/src/main/java/com/bynder/sdk/util/Utils.java
@@ -102,9 +102,11 @@ public final class Utils {
         httpClient.interceptors().clear();
         httpClient.addInterceptor(new SigningInterceptor(consumer));
 
-        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
-        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-        httpClient.addInterceptor(interceptor);
+        if (httpConnectionSettings.isLoggingInterceptorEnabled()) {
+            HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
+            interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+            httpClient.addInterceptor(interceptor);
+        }
 
         if (httpConnectionSettings.getCustomInterceptor() != null) {
             httpClient.addInterceptor(httpConnectionSettings.getCustomInterceptor());


### PR DESCRIPTION
We've noticed that the HttpClient used by the Bynder SDK logs the request headers and the response headers/body, at `INFO` level:

    2018-04-06 10:30:57.174  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : --> GET https://marketingportal.wolfoil.com/api/v4/media/?keyword=poster http/1.1
    2018-04-06 10:30:57.174  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : Authorization: OAuth oauth_consumer_key="XXXXX", oauth_nonce="XXXXX", oauth_signature="XXXXX", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1523003457", oauth_token="XXXXX", oauth_version="1.0"
    2018-04-06 10:30:57.174  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : --> END GET
    2018-04-06 10:30:57.527  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : <-- 200 OK https://marketingportal.wolfoil.com/api/v4/media/?keyword=poster (352ms)
    2018-04-06 10:30:57.527  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : Server: nginx
    2018-04-06 10:30:57.527  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : Date: Fri, 06 Apr 2018 08:30:53 GMT
    2018-04-06 10:30:57.527  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : Content-Type: application/json;charset=UTF-8
    2018-04-06 10:30:57.527  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : Content-Length: 96715
    2018-04-06 10:30:57.527  INFO 49627 --- [nio-8080-exec-3] okhttp3.OkHttpClient                     : Connection: keep-alive

Since the request headers contain the raw authorization values, logging this by default is not a good idea, at least not at the default `INFO` level. 

Raising the log-level for that particular logger (named `okhttp3.OkHttpClient`) would prevent the logs from ending up in the logs, but the `HttpLoggingInterceptor` still builds/concatenates the message to be logged, regardless of the logger being enabled at this level. For large payloads, this may result in a performance penalty.

My suggested pull-request is backwards compatible with the current behaviour: adding the logging interceptor by default and still exposing a the existing `HttpLoggingInterceptor`constructor without the additional parameter. It allows to disable adding the logging filter.

However, IMHO it seems like the default should be not to include it by default as this interceptor should be used for debugging/development.