### PR TITLE
Upload asset as additional file

### DIFF
--- a/src/main/java/com/bynder/sdk/api/BynderApi.java
+++ b/src/main/java/com/bynder/sdk/api/BynderApi.java
@@ -15,6 +15,7 @@ import com.bynder.sdk.model.Metaproperty;
 import com.bynder.sdk.model.Smartfilter;
 import com.bynder.sdk.model.Tag;
 import com.bynder.sdk.model.Usage;
+import com.bynder.sdk.model.upload.FinaliseAdditionalFileResponse;
 import com.bynder.sdk.model.upload.FinaliseResponse;
 import com.bynder.sdk.model.upload.PollStatus;
 import com.bynder.sdk.model.upload.SaveMediaResponse;
@@ -283,6 +284,11 @@ public interface BynderApi {
     @FormUrlEncoded
     @POST("/api/v4/upload/")
     Observable<Response<FinaliseResponse>> finaliseUpload(@FieldMap Map<String, String> params);
+
+    @FormUrlEncoded
+    @POST("/api/v4/media/{id}/save/additional/{uploadId}/")
+    Observable<Response<FinaliseAdditionalFileResponse>> finaliseAdditionalFileUpload(@Path("id") String id,
+        @Path("uploadId") String uploadId, @FieldMap Map<String, String> params);
 
     /**
      * Gets poll processing status of finalised files.

--- a/src/main/java/com/bynder/sdk/model/upload/FinaliseAdditionalFileResponse.java
+++ b/src/main/java/com/bynder/sdk/model/upload/FinaliseAdditionalFileResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Bynder B.V. All rights reserved.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license
+ * information.
+ */
+package com.bynder.sdk.model.upload;
+
+import java.util.Map;
+
+import com.bynder.sdk.api.BynderApi;
+
+/**
+ * Model returned by {@link BynderApi#finaliseAdditionalFileUpload(String, String, Map)}.
+ */
+public class FinaliseAdditionalFileResponse {
+
+    /**
+     * Item id of the upload.
+     */
+    private String itemId;
+
+    public String getItemId() {
+        return itemId;
+    }
+}

--- a/src/main/java/com/bynder/sdk/model/upload/UploadProgress.java
+++ b/src/main/java/com/bynder/sdk/model/upload/UploadProgress.java
@@ -26,6 +26,10 @@ public class UploadProgress {
      */
     private SaveMediaResponse saveMediaResponse;
     /**
+     * The Id of uploaded additional file, filled, when upload is finished.
+     */
+    private FinaliseAdditionalFileResponse finaliseAdditionalFileResponse;
+    /**
      * The number of chunks already successfully uploaded.
      */
     private int uploadedChunks;
@@ -55,6 +59,14 @@ public class UploadProgress {
 
     public void setSaveMediaResponse(SaveMediaResponse saveMediaResponse) {
         this.saveMediaResponse = saveMediaResponse;
+    }
+
+    public FinaliseAdditionalFileResponse getFinaliseAdditionalFileResponse() {
+        return finaliseAdditionalFileResponse;
+    }
+
+    public void setFinaliseAdditionalFileResponse(FinaliseAdditionalFileResponse finaliseAdditionalFileResponse) {
+        this.finaliseAdditionalFileResponse = finaliseAdditionalFileResponse;
     }
 
     /**

--- a/src/main/java/com/bynder/sdk/query/upload/UploadQuery.java
+++ b/src/main/java/com/bynder/sdk/query/upload/UploadQuery.java
@@ -21,7 +21,8 @@ public class UploadQuery {
     private final String brandId;
     /**
      * Media id. If specified it will add the media asset file as new version of the specified
-     * media. Otherwise a new media asset will be added to the asset bank.
+     * media or as new additional file of specified media depending on called method.
+     * If is not specified, a new media asset will be added to the asset bank.
      */
     private String mediaId;
     /**

--- a/src/main/java/com/bynder/sdk/service/asset/AssetService.java
+++ b/src/main/java/com/bynder/sdk/service/asset/AssetService.java
@@ -14,6 +14,7 @@ import com.bynder.sdk.model.Metaproperty;
 import com.bynder.sdk.model.Smartfilter;
 import com.bynder.sdk.model.Tag;
 import com.bynder.sdk.model.Usage;
+import com.bynder.sdk.model.upload.FinaliseAdditionalFileResponse;
 import com.bynder.sdk.model.upload.SaveMediaResponse;
 import com.bynder.sdk.model.upload.UploadProgress;
 import com.bynder.sdk.query.MediaDeleteQuery;
@@ -150,6 +151,14 @@ public interface AssetService {
      * @return {@link Observable} with the {@link UploadProgress} information.
      */
     Observable<UploadProgress> uploadFileWithProgress(UploadQuery uploadQuery);
+
+    /**
+     * Uploads an additional file to existing asset.
+     *
+     * @param uploadQuery Upload query with the information to upload the file.
+     * @return {@link Observable} with the {@link FinaliseAdditionalFileResponse} information.
+     */
+    Observable<FinaliseAdditionalFileResponse> uploadAdditionalFile(UploadQuery uploadQuery);
 
     /**
      * Builder class used to create a new instance of {@link AssetService}.

--- a/src/main/java/com/bynder/sdk/service/asset/AssetServiceImpl.java
+++ b/src/main/java/com/bynder/sdk/service/asset/AssetServiceImpl.java
@@ -14,6 +14,7 @@ import com.bynder.sdk.model.Metaproperty;
 import com.bynder.sdk.model.Smartfilter;
 import com.bynder.sdk.model.Tag;
 import com.bynder.sdk.model.Usage;
+import com.bynder.sdk.model.upload.FinaliseAdditionalFileResponse;
 import com.bynder.sdk.model.upload.SaveMediaResponse;
 import com.bynder.sdk.model.upload.UploadProgress;
 import com.bynder.sdk.query.MediaDeleteQuery;
@@ -188,5 +189,13 @@ public class AssetServiceImpl implements AssetService {
     @Override
     public Observable<UploadProgress> uploadFileWithProgress(final UploadQuery uploadQuery) {
         return fileUploader.uploadFileWithProgress(uploadQuery);
+    }
+
+    /**
+     * Check {@link AssetService} for more information.
+     */
+    @Override
+    public Observable<FinaliseAdditionalFileResponse> uploadAdditionalFile(final UploadQuery uploadQuery) {
+        return fileUploader.uploadAdditionalFile(uploadQuery);
     }
 }


### PR DESCRIPTION
Add method `Observable<FinaliseAdditionalFileResponse> uploadAdditionalFile(UploadQuery uploadQuery);` that enables API users to upload assets as an additional file of existing asset.