### PR TITLE
Patch to prune coveralls now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Maven Package
         run: mvn clean install -Dgpg.skip -Dmaven.javadoc.skip -Dmaven.test.skip
       - name: Tests with Coverage
-        run: mvn clean test jacoco:report coveralls:report -DrepoToken=${{secrets.COVERALLS_TOKEN}}
+        run: mvn clean test jacoco:report
 
   release:
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Maven Package
         run: mvn clean install -Dgpg.skip -Dmaven.javadoc.skip -Dmaven.test.skip
       - name: Tests with Coverage
-        run: mvn clean test jacoco:report coveralls:report -DrepoToken=${{secrets.COVERALLS_TOKEN}}
+        run: mvn clean test jacoco:report


### PR DESCRIPTION
The coveralls report coverage is raising errors such as this:

[https://github.com/Bynder/bynder-java-sdk/actions/runs/452732628](https://github.com/Bynder/bynder-java-sdk/actions/runs/452732628)

This needs further investigation and can be added as part of this [ticket](https://bynder.atlassian.net/browse/API-197) along with other cleanup. jacoco will generate reports for now in the actions console.