### PR TITLE
API-751: Add logic to set an asset as Limited during when modifying an asset

### DIFF
--- a/src/main/java/com/bynder/sdk/model/Media.java
+++ b/src/main/java/com/bynder/sdk/model/Media.java
@@ -80,6 +80,11 @@ public class Media {
      */
     private Boolean isPublic;
     /**
+     * Media limited status.
+     */
+    @SerializedName(value = "limited")
+    private Boolean isLimited;
+    /**
      * Media original URL.
      */
     private String original;
@@ -174,6 +179,10 @@ public class Media {
 
     public Boolean isPublic() {
         return isPublic;
+    }
+
+    public Boolean isLimited() {
+        return isLimited;
     }
 
     public String getOriginal() {

--- a/src/main/java/com/bynder/sdk/query/MediaModifyQuery.java
+++ b/src/main/java/com/bynder/sdk/query/MediaModifyQuery.java
@@ -54,6 +54,18 @@ public class MediaModifyQuery {
     private String datePublished;
 
     /**
+     * Limited new status.
+     */
+    @ApiField
+    private Boolean limited;
+
+    /**
+     * Date limited new value.
+     */
+    @ApiField
+    private String limitedDate;
+
+    /**
      * Dictionary with (metaproperty) options to set on the asset.
      */
     @ApiField(name = "metaproperty", decoder = MetapropertyAttributesDecoder.class)
@@ -91,6 +103,24 @@ public class MediaModifyQuery {
 
     public MediaModifyQuery setMetaproperties(List<MetapropertyAttribute> metaproperties) {
         this.metaproperties = metaproperties;
+        return this;
+    }
+
+    public Boolean getLimited() {
+        return limited;
+    }
+
+    public String getLimitedDate() {
+        return limitedDate;
+    }
+
+    public MediaModifyQuery setLimited(final Boolean limited) {
+        this.limited = limited;
+        return this;
+    }
+
+    public MediaModifyQuery setLimitedDate(final String limitedDate) {
+        this.limitedDate = limitedDate;
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/query/MediaQuery.java
+++ b/src/main/java/com/bynder/sdk/query/MediaQuery.java
@@ -38,6 +38,12 @@ public class MediaQuery {
     @ApiField(decoder = BooleanParameterDecoder.class)
     private Boolean isPublic;
     /**
+     * This property has to be set to 1 (TRUE) for the API to also retrieve media assets marked as
+     * limited.
+     */
+    @ApiField(decoder = BooleanParameterDecoder.class)
+    private Boolean limited;
+    /**
      * Whether to fetch the media item information or not.
      */
     @ApiField(decoder = BooleanParameterDecoder.class)
@@ -92,6 +98,15 @@ public class MediaQuery {
 
     public MediaQuery setIsPublic(final Boolean isPublic) {
         this.isPublic = isPublic;
+        return this;
+    }
+
+    public Boolean getLimited() {
+        return limited;
+    }
+
+    public MediaQuery setLimited(final Boolean limited) {
+        this.limited = limited;
         return this;
     }
 

--- a/src/test/java/com/bynder/sdk/query/MediaModifyQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/MediaModifyQueryTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Bynder B.V. All rights reserved.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license
+ * information.
+ *
+ * JUnit framework component copyright (c) 2002-2017 JUnit. All Rights Reserved. Licensed under
+ * Eclipse Public License - v 1.0. You may obtain a copy of the License at
+ * https://www.eclipse.org/legal/epl-v10.html.
+ */
+package com.bynder.sdk.query;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Tests the {@link MediaModifyQuery} class methods.
+ */
+public class MediaModifyQueryTest {
+    public static final String EXPECTED_MEDIA_ID = "id";
+    public static final Boolean EXPECTED_LIMITED = true;
+    public static final String EXPECTED_LIMITED_DATE = "2014-12-25T10:30:00Z";
+
+    @Test
+    public void initializeMediaModifyQueryTest() {
+        MediaModifyQuery mediaModifyQuery = new MediaModifyQuery(EXPECTED_MEDIA_ID);
+        mediaModifyQuery.setLimited(EXPECTED_LIMITED);
+        assertEquals(EXPECTED_LIMITED, mediaModifyQuery.getLimited());
+
+        mediaModifyQuery.setLimitedDate(EXPECTED_LIMITED_DATE);
+        assertEquals(EXPECTED_LIMITED_DATE, mediaModifyQuery.getLimitedDate());
+
+    }
+}

--- a/src/test/java/com/bynder/sdk/query/MediaQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/MediaQueryTest.java
@@ -64,6 +64,9 @@ public class MediaQueryTest {
         mediaQuery.setIsPublic(EXPECTED_BOOLEAN);
         assertEquals(EXPECTED_BOOLEAN, mediaQuery.getIsPublic());
 
+        mediaQuery.setLimited(EXPECTED_BOOLEAN);
+        assertEquals(EXPECTED_BOOLEAN, mediaQuery.getLimited());
+
         mediaQuery.setLimit(EXPECTED_INTEGER);
         assertEquals(EXPECTED_INTEGER, mediaQuery.getLimit().intValue());
 


### PR DESCRIPTION
[JIRA](https://bynder.atlassian.net/browse/API-751)

- support limited and limitedDate on MediaModifyQuery to modify an asset
- support fetching limited assets via the MediaQuery to retrieve assets
- tests