### PR TITLE
API-752: Support tags on modify media and asset uploads on master

### DIFF
--- a/src/main/java/com/bynder/sdk/query/MediaModifyQuery.java
+++ b/src/main/java/com/bynder/sdk/query/MediaModifyQuery.java
@@ -66,6 +66,12 @@ public class MediaModifyQuery {
     private String limitedDate;
 
     /**
+     * Tags new value.
+     */
+    @ApiField
+    private String tags;
+
+    /**
      * Dictionary with (metaproperty) options to set on the asset.
      */
     @ApiField(name = "metaproperty", decoder = MetapropertyAttributesDecoder.class)
@@ -121,6 +127,15 @@ public class MediaModifyQuery {
 
     public MediaModifyQuery setLimitedDate(final String limitedDate) {
         this.limitedDate = limitedDate;
+        return this;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public MediaModifyQuery setTags(final List<String> tags) {
+        this.tags = String.join(",", tags);
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/query/MediaQuery.java
+++ b/src/main/java/com/bynder/sdk/query/MediaQuery.java
@@ -12,6 +12,7 @@ import com.bynder.sdk.query.decoder.BooleanParameterDecoder;
 import com.bynder.sdk.query.decoder.MetapropertyParameterDecoder;
 import com.bynder.sdk.query.decoder.StringArrayParameterDecoder;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -58,6 +59,11 @@ public class MediaQuery {
      */
     @ApiField
     private Integer page;
+    /**
+     * Comma-separated tags to be retrieved.
+     */
+    @ApiField
+    private String tags;
     /**
      * Metaproperty option ids that the media asset needs to have at least one of.
      */
@@ -134,6 +140,15 @@ public class MediaQuery {
 
     public MediaQuery setPage(final Integer page) {
         this.page = page;
+        return this;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public MediaQuery setTags(final List<String> tags) {
+        this.tags = String.join(",", tags);
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/query/upload/SaveMediaQuery.java
+++ b/src/main/java/com/bynder/sdk/query/upload/SaveMediaQuery.java
@@ -49,6 +49,12 @@ public class SaveMediaQuery {
     private Boolean audit;
 
     /**
+     * Comma-separated list of tags to be set on the asset.
+     */
+    @ApiField
+    private String tags;
+
+    /**
      * Dictionary with (metaproperty) options to set on the asset upon upload.
      */
     @ApiField(name = "metaproperty", decoder = MetapropertyAttributesDecoder.class)
@@ -76,6 +82,11 @@ public class SaveMediaQuery {
 
     public SaveMediaQuery setAudit(final Boolean audit) {
         this.audit = audit;
+        return this;
+    }
+
+    public SaveMediaQuery setTags(final String tags) {
+        this.tags = tags;
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/query/upload/UploadQuery.java
+++ b/src/main/java/com/bynder/sdk/query/upload/UploadQuery.java
@@ -39,6 +39,11 @@ public class UploadQuery {
     private Boolean audit;
 
     /**
+     * Tags to be set upon the asset on an upload.
+     */
+    private String tags;
+
+    /**
      * list of metaproperties and options to set on the asset upon upload.
      */
     private List<MetapropertyAttribute> metaproperties;
@@ -75,6 +80,15 @@ public class UploadQuery {
 
     public UploadQuery setAudit(final Boolean audit) {
         this.audit = audit;
+        return this;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public UploadQuery setTags(final List<String> tags) {
+        this.tags = String.join(",", tags);
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/service/upload/FileUploader.java
+++ b/src/main/java/com/bynder/sdk/service/upload/FileUploader.java
@@ -169,10 +169,11 @@ public class FileUploader {
                 .setMetaproperties(uploadQuery.getMetaproperties());
 
         if (uploadQuery.getMediaId() == null) {
-            // A new asset will be created for the upoaded file.
+            // A new asset will be created for the uploaded file.
             return saveMedia(saveMediaQuery
                     .setBrandId(uploadQuery.getBrandId())
                     .setName(uploadQuery.getFilename())
+                    .setTags(uploadQuery.getTags())
             );
         } else {
             // The uploaded file will be attached to an existing asset.

--- a/src/test/java/com/bynder/sdk/query/MediaModifyQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/MediaModifyQueryTest.java
@@ -12,6 +12,8 @@ package com.bynder.sdk.query;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertEquals;
 
 
@@ -22,6 +24,7 @@ public class MediaModifyQueryTest {
     public static final String EXPECTED_MEDIA_ID = "id";
     public static final Boolean EXPECTED_LIMITED = true;
     public static final String EXPECTED_LIMITED_DATE = "2014-12-25T10:30:00Z";
+    public static final String EXPECTED_TAGS = "tag1,tag2";
 
     @Test
     public void initializeMediaModifyQueryTest() {
@@ -31,6 +34,9 @@ public class MediaModifyQueryTest {
 
         mediaModifyQuery.setLimitedDate(EXPECTED_LIMITED_DATE);
         assertEquals(EXPECTED_LIMITED_DATE, mediaModifyQuery.getLimitedDate());
+
+        mediaModifyQuery.setTags(Arrays.asList("tag1", "tag2"));
+        assertEquals(EXPECTED_TAGS, mediaModifyQuery.getTags());
 
     }
 }

--- a/src/test/java/com/bynder/sdk/query/MediaQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/MediaQueryTest.java
@@ -14,6 +14,7 @@ import com.bynder.sdk.model.MediaType;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -33,6 +34,7 @@ public class MediaQueryTest {
     public static final OrderBy EXPECTED_ORDER = OrderBy.DATE_CREATED_ASC;
     public static final String EXPECTED_METAPROPERTY_NAME = "metapropertyName";
     public static final String EXPECTED_METAPROPERTY_OPTION = "metapropertyOption";
+    public static final String EXPECTED_TAGS = "tag1,tag2";
 
     private MediaQuery mediaQuery;
 
@@ -69,6 +71,9 @@ public class MediaQueryTest {
 
         mediaQuery.setLimit(EXPECTED_INTEGER);
         assertEquals(EXPECTED_INTEGER, mediaQuery.getLimit().intValue());
+
+        mediaQuery.setTags(Arrays.asList("tag1", "tag2"));
+        assertEquals(EXPECTED_TAGS, mediaQuery.getTags());
 
         mediaQuery.setPage(EXPECTED_INTEGER);
         assertEquals(EXPECTED_INTEGER, mediaQuery.getPage().intValue());

--- a/src/test/java/com/bynder/sdk/query/upload/UploadQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/upload/UploadQueryTest.java
@@ -4,6 +4,7 @@ import com.bynder.sdk.query.MetapropertyAttribute;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -20,6 +21,7 @@ public class UploadQueryTest {
     public static final String EXPECTED_METAPROPERTY_ID = "metapropertyId";
     public static final String EXPECTED_OPTION_NAME = "optionName";
     public static final Boolean EXPECTED_AUDIT = Boolean.TRUE;
+    public static final String EXPECTED_TAGS = "tag1,tag2";
     public static final List<MetapropertyAttribute> EXPECTED_METAPROPERTIES = new ArrayList<>();
     public static final MetapropertyAttribute EXPECTED_METAPROPERTY = new MetapropertyAttribute(EXPECTED_METAPROPERTY_ID, new String[]{EXPECTED_OPTION_NAME});
     static {
@@ -32,6 +34,7 @@ public class UploadQueryTest {
         UploadQuery uploadQuery = new UploadQuery(EXPECTED_FILE_PATH, EXPECTED_BRAND_ID);
         uploadQuery.setMediaId(EXPECTED_MEDIA_ID);
         uploadQuery.setAudit(EXPECTED_AUDIT);
+        uploadQuery.setTags(Arrays.asList("tag1", "tag2"));
         uploadQuery.addMetaproperty(EXPECTED_METAPROPERTY_ID, EXPECTED_OPTION_NAME);
 
         assertTrue(EXPECTED_METAPROPERTY.equals(uploadQuery.getMetaproperties().get(0)));
@@ -39,6 +42,7 @@ public class UploadQueryTest {
         assertEquals(EXPECTED_BRAND_ID, uploadQuery.getBrandId());
         assertEquals(EXPECTED_MEDIA_ID, uploadQuery.getMediaId());
         assertEquals(EXPECTED_AUDIT, uploadQuery.isAudit());
+        assertEquals(EXPECTED_TAGS, uploadQuery.getTags());
     }
     
         @Test


### PR DESCRIPTION
[JIRA](https://bynder.atlassian.net/browse/API-752)

- support tags as a query param to MediaModifyQuery, MediaQuery
- support addition of tags while uploading assets via SaveMediaQuery, UploadQuery and FileUploader
- tests