### PR TITLE
API-752: Support tags on modify media and asset uploads on FS_upload_dev

### DIFF
--- a/src/main/java/com/bynder/sdk/query/MediaModifyQuery.java
+++ b/src/main/java/com/bynder/sdk/query/MediaModifyQuery.java
@@ -66,6 +66,12 @@ public class MediaModifyQuery {
     private String limitedDate;
 
     /**
+     * Tags new value.
+     */
+    @ApiField
+    private String tags;
+
+    /**
      * Dictionary with (metaproperty) options to set on the asset.
      */
     @ApiField(name = "metaproperty", decoder = MetapropertyAttributesDecoder.class)
@@ -121,6 +127,15 @@ public class MediaModifyQuery {
 
     public MediaModifyQuery setLimitedDate(final String limitedDate) {
         this.limitedDate = limitedDate;
+        return this;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public MediaModifyQuery setTags(final List<String> tags) {
+        this.tags = String.join(",", tags);
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/query/upload/NewAssetUploadQuery.java
+++ b/src/main/java/com/bynder/sdk/query/upload/NewAssetUploadQuery.java
@@ -22,6 +22,11 @@ public class NewAssetUploadQuery extends UploadQuery {
      */
     private List<MetapropertyAttribute> metaproperties;
 
+    /**
+     * comma-separated list of tags to set on the asset upon upload.
+     */
+    private String tags;
+
     public NewAssetUploadQuery(String filepath, String brandId) {
         super(filepath);
         this.brandId = brandId;
@@ -37,6 +42,15 @@ public class NewAssetUploadQuery extends UploadQuery {
 
     public UploadQuery setAudit(final Boolean audit) {
         this.audit = audit;
+        return this;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public UploadQuery setTags(final List<String> tags) {
+        this.tags = String.join(",", tags);
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/query/upload/SaveMediaQuery.java
+++ b/src/main/java/com/bynder/sdk/query/upload/SaveMediaQuery.java
@@ -37,6 +37,12 @@ public class SaveMediaQuery {
     private Boolean audit;
 
     /**
+     * Comma-separated list of tags to be set on the asset.
+     */
+    @ApiField
+    private String tags;
+
+    /**
      * Dictionary with metaproperty options to set on the asset upon upload.
      */
     @ApiField(name = "metaproperty", decoder = MetapropertyAttributesDecoder.class)
@@ -58,6 +64,11 @@ public class SaveMediaQuery {
 
     public SaveMediaQuery setAudit(final Boolean audit) {
         this.audit = audit;
+        return this;
+    }
+
+    public SaveMediaQuery setTags(final String tags) {
+        this.tags = tags;
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/sample/AppSample.java
+++ b/src/main/java/com/bynder/sdk/sample/AppSample.java
@@ -115,7 +115,7 @@ public class AppSample {
     public void uploadFile(final String uploadPath) {
         assetService.getBrands().singleOrError().map(RXUtils::getResponseBody).flatMap(brands ->
                 assetService.uploadFile(
-                        new NewAssetUploadQuery(uploadPath, brands.get(0).getId())
+                        (NewAssetUploadQuery) (new NewAssetUploadQuery(uploadPath, brands.get(0).getId())).setTags(Arrays.asList("tag1", "tag2"))
                 )
         ).flatMap(saveMediaResponse -> {
             LOG.info("New asset successfully created: " + saveMediaResponse.getMediaId());
@@ -137,7 +137,7 @@ public class AppSample {
                     LOG.error("New asset version could not be fetched after trying 5 times.")
             ).singleOrError();
         }).flatMapCompletable(media -> {
-            LOG.info("New asset version could be fetched: " + media.getId() + " " + media.getName());
+            LOG.info("New asset version could be fetched: " + media.getId() + " " + media.getName() + " " + media.getTags());
             return assetService.deleteMedia(new MediaDeleteQuery(media.getId())).map(RXUtils::ensureSuccessResponse).ignoreElements();
         }).blockingAwait();
     }

--- a/src/main/java/com/bynder/sdk/service/upload/FileUploader.java
+++ b/src/main/java/com/bynder/sdk/service/upload/FileUploader.java
@@ -106,6 +106,7 @@ public class FileUploader {
                         .setBrandId(uploadQuery.getBrandId())
                         .setName(uploadQuery.getFilename())
                         .setAudit(uploadQuery.isAudit())
+                        .setTags(uploadQuery.getTags())
                         .setMetaproperties(uploadQuery.getMetaproperties()))
         ).map(RXUtils::getResponseBody);
     }

--- a/src/test/java/com/bynder/sdk/query/MediaModifyQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/MediaModifyQueryTest.java
@@ -12,6 +12,8 @@ package com.bynder.sdk.query;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertEquals;
 
 
@@ -22,6 +24,7 @@ public class MediaModifyQueryTest {
     public static final String EXPECTED_MEDIA_ID = "id";
     public static final Boolean EXPECTED_LIMITED = true;
     public static final String EXPECTED_LIMITED_DATE = "2014-12-25T10:30:00Z";
+    public static final String EXPECTED_TAGS = "tag1,tag2";
 
     @Test
     public void initializeMediaModifyQueryTest() {
@@ -31,6 +34,9 @@ public class MediaModifyQueryTest {
 
         mediaModifyQuery.setLimitedDate(EXPECTED_LIMITED_DATE);
         assertEquals(EXPECTED_LIMITED_DATE, mediaModifyQuery.getLimitedDate());
+
+        mediaModifyQuery.setTags(Arrays.asList("tag1", "tag2"));
+        assertEquals(EXPECTED_TAGS, mediaModifyQuery.getTags());
 
     }
 }

--- a/src/test/java/com/bynder/sdk/service/upload/FileUploaderTest.java
+++ b/src/test/java/com/bynder/sdk/service/upload/FileUploaderTest.java
@@ -126,6 +126,7 @@ public class FileUploaderTest {
                 queryDecoder.decode(new SaveMediaQuery()
                         .setName(uploadQuery.getFilename())
                         .setAudit(uploadQuery.isAudit())
+                        .setTags(uploadQuery.getTags())
                         .setMetaproperties(uploadQuery.getMetaproperties())
                         .setBrandId(uploadQuery.getBrandId())
                 )


### PR DESCRIPTION
[JIRA](https://bynder.atlassian.net/browse/API-752)

- support tags as a query param to MediaModifyQuery
- support addition of tags while uploading assets via SaveMediaQuery, NewAssetUploadQuery and FileUploader
- add tags in the sample app
- tests