### PR TITLE
Support fileName on saveMedia method

### DIFF
--- a/src/main/java/com/bynder/sdk/query/upload/UploadQuery.java
+++ b/src/main/java/com/bynder/sdk/query/upload/UploadQuery.java
@@ -48,6 +48,11 @@ public class UploadQuery {
      */
     private List<MetapropertyAttribute> metaproperties;
 
+    /**
+     * Name of the file to upload
+     */
+    private String name;
+
     public UploadQuery(final String filepath, final String brandId) {
         this.filepath = filepath;
         this.brandId = brandId;
@@ -69,6 +74,10 @@ public class UploadQuery {
         return mediaId;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public UploadQuery setMediaId(final String mediaId) {
         this.mediaId = mediaId;
         return this;
@@ -80,6 +89,11 @@ public class UploadQuery {
 
     public UploadQuery setAudit(final Boolean audit) {
         this.audit = audit;
+        return this;
+    }
+
+    public UploadQuery setName(final String name) {
+        this.name = name;
         return this;
     }
 

--- a/src/main/java/com/bynder/sdk/sample/AppSample.java
+++ b/src/main/java/com/bynder/sdk/sample/AppSample.java
@@ -67,6 +67,8 @@ public class AppSample {
         String filePath = "your-absolute-filepath";
         String brandId = "your-brand-id";
         UploadQuery uploadQuery = new UploadQuery(filePath, brandId);
+        // Add the filename you want specifiy in this manner
+        uploadQuery.setName("your-filename");
         SaveMediaResponse saveMediaResponse = assetService.uploadFile(uploadQuery).blockingSingle();
 
         // Optional: define callback function to be triggered after access token is auto

--- a/src/main/java/com/bynder/sdk/service/upload/FileUploader.java
+++ b/src/main/java/com/bynder/sdk/service/upload/FileUploader.java
@@ -167,12 +167,15 @@ public class FileUploader {
         SaveMediaQuery saveMediaQuery = new SaveMediaQuery(importId)
                 .setAudit(uploadQuery.isAudit())
                 .setMetaproperties(uploadQuery.getMetaproperties());
+        String fileName = uploadQuery.getName();
+        if (fileName == null)
+            fileName = uploadQuery.getFilename();
 
         if (uploadQuery.getMediaId() == null) {
             // A new asset will be created for the uploaded file.
             return saveMedia(saveMediaQuery
                     .setBrandId(uploadQuery.getBrandId())
-                    .setName(uploadQuery.getFilename())
+                    .setName(fileName)
                     .setTags(uploadQuery.getTags())
             );
         } else {

--- a/src/test/java/com/bynder/sdk/query/upload/UploadQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/upload/UploadQueryTest.java
@@ -22,6 +22,7 @@ public class UploadQueryTest {
     public static final String EXPECTED_OPTION_NAME = "optionName";
     public static final Boolean EXPECTED_AUDIT = Boolean.TRUE;
     public static final String EXPECTED_TAGS = "tag1,tag2";
+    public static final String EXPECTED_NAME = "name";
     public static final List<MetapropertyAttribute> EXPECTED_METAPROPERTIES = new ArrayList<>();
     public static final MetapropertyAttribute EXPECTED_METAPROPERTY = new MetapropertyAttribute(EXPECTED_METAPROPERTY_ID, new String[]{EXPECTED_OPTION_NAME});
     static {
@@ -36,6 +37,7 @@ public class UploadQueryTest {
         uploadQuery.setAudit(EXPECTED_AUDIT);
         uploadQuery.setTags(Arrays.asList("tag1", "tag2"));
         uploadQuery.addMetaproperty(EXPECTED_METAPROPERTY_ID, EXPECTED_OPTION_NAME);
+        uploadQuery.setName(EXPECTED_NAME);
 
         assertTrue(EXPECTED_METAPROPERTY.equals(uploadQuery.getMetaproperties().get(0)));
         assertEquals(EXPECTED_FILE_PATH, uploadQuery.getFilepath());
@@ -43,6 +45,7 @@ public class UploadQueryTest {
         assertEquals(EXPECTED_MEDIA_ID, uploadQuery.getMediaId());
         assertEquals(EXPECTED_AUDIT, uploadQuery.isAudit());
         assertEquals(EXPECTED_TAGS, uploadQuery.getTags());
+        assertEquals(EXPECTED_NAME, uploadQuery.getName());
     }
     
         @Test


### PR DESCRIPTION
This PR adds support to be able to add `name` to the `media/save` call of an upload