### PR TITLE
FSB-5668 Old Version of com.google.code.gson:gson v2.8.5 (CVE-2022-25647)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Observable<Response<Void>> shareCollection(CollectionShareQuery collectionShareQ
 
 ### Using latest release
 
-The most recent release is Bynder Java SDK 2.2.17.
+The most recent release is Bynder Java SDK 2.2.18.
 
-- API Docs: http://www.javadoc.io/doc/com.bynder/bynder-java-sdk/2.2.17
+- API Docs: http://www.javadoc.io/doc/com.bynder/bynder-java-sdk/2.2.18
 
 To add a dependency on the SDK using Maven, use the following:
 
@@ -99,7 +99,7 @@ To add a dependency on the SDK using Maven, use the following:
 <dependency>
   <groupId>com.bynder</groupId>
   <artifactId>bynder-java-sdk</artifactId>
-  <version>2.2.17</version>
+  <version>2.2.18</version>
 </dependency>
 ```
 
@@ -107,7 +107,7 @@ To add a dependency using Gradle:
 
 ```
 dependencies {
-  implementation 'com.bynder:bynder-java-sdk:2.2.17'
+  implementation 'com.bynder:bynder-java-sdk:2.2.18'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.bynder</groupId>
     <artifactId>bynder-java-sdk</artifactId>
-    <version>2.2.17</version>
+    <version>2.2.18</version>
     <packaging>jar</packaging>
 
     <name>Bynder Java SDK</name>
@@ -72,6 +72,12 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-gson</artifactId>
             <version>2.9.0</version>
+        </dependency>
+        <!-- override com.google.code.gson version for security issue used in converter-gson, nearest definition -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>


### PR DESCRIPTION
https://bynder.atlassian.net/browse/FSB-5668

Dependency `converter-gson` version `2.9.0` has a compile/transitive dependency on `com.google.code.gson` version `2.8.5` (https://mvnrepository.com/artifact/com.squareup.retrofit2/converter-gson/2.9.0). Version `2.8.5` has a security vulnerability (https://mvnrepository.com/artifact/com.google.code.gson/gson/2.8.5) referencing CVE-2022-25647. 

Referencing https://fossa.com/blog/overriding-dependency-versions-using-version-ranges-maven/, added a direct dependency of `com.google.code.gson` with version `2.10.1`. With nearest definition in pom.xml, `converter-gson` picks up version `2.10.1` of `com.google.code.gson`. 