### PR TITLE
Implement Issue #107 - add properties "options" and "id" to class Met…

### DIFF
--- a/src/main/java/com/bynder/sdk/query/MetapropertyQuery.java
+++ b/src/main/java/com/bynder/sdk/query/MetapropertyQuery.java
@@ -26,6 +26,18 @@ public class MetapropertyQuery {
      */
     @ApiField
     private MediaType type;
+    /**
+     * Make it possible to get metaproperties without options, to avoid possible timeout if the number
+     *  of metapropertiy/options is very large (e.g. with Stockholm National Museum taxonomies)
+     * @author Colin Manning - zetcom
+     */
+    @ApiField
+    private Boolean options;
+    /**
+     * The id of a Metaproperty, to get the information for one specific metaproperty
+     * @author Colin Manning - zetcom
+     */    @ApiField
+    private String id;
 
     public Boolean getCount() {
         return count;
@@ -42,6 +54,23 @@ public class MetapropertyQuery {
 
     public MetapropertyQuery setType(final MediaType type) {
         this.type = type;
+        return this;
+    }
+
+    public Boolean getOptions() {
+        return options;
+    }
+
+    public MetapropertyQuery setOptions(final Boolean options) {
+        this.options = options;
+        return this;
+    }
+    public String getId() {
+        return id;
+    }
+
+    public MetapropertyQuery setId(final String id) {
+        this.id = id;
         return this;
     }
 }

--- a/src/main/java/com/bynder/sdk/query/MetapropertyQuery.java
+++ b/src/main/java/com/bynder/sdk/query/MetapropertyQuery.java
@@ -34,10 +34,13 @@ public class MetapropertyQuery {
     @ApiField
     private Boolean options;
     /**
-     * The id of a Metaproperty, to get the information for one specific metaproperty
+     * A collection id of a Metaproperty, to get the information for specific metaproperties
+     * Most common use case will be to fetch a single metaproperty,
+     * but we need to use "ids" and not "id" to get a Map back or else the API breaks
      * @author Colin Manning - zetcom
-     */    @ApiField
-    private String id;
+     */
+    @ApiField
+    private String ids;
 
     public Boolean getCount() {
         return count;
@@ -65,12 +68,12 @@ public class MetapropertyQuery {
         this.options = options;
         return this;
     }
-    public String getId() {
-        return id;
+    public String getIds() {
+        return ids;
     }
 
-    public MetapropertyQuery setId(final String id) {
-        this.id = id;
+    public MetapropertyQuery setIds(final String ids) {
+        this.ids = ids;
         return this;
     }
 }

--- a/src/test/java/com/bynder/sdk/query/MetapropertyQueryTest.java
+++ b/src/test/java/com/bynder/sdk/query/MetapropertyQueryTest.java
@@ -1,0 +1,51 @@
+package com.bynder.sdk.query;
+
+import com.bynder.sdk.model.MediaType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests the {@link MetapropertyQuery} class methods.
+ */
+public class MetapropertyQueryTest {
+
+    public static final MediaType EXPECTED_MEDIA_TYPE = MediaType.IMAGE;
+    public static final int EXPECTED_INTEGER = 1;
+    public static final Boolean EXPECTED_BOOLEAN = Boolean.TRUE;
+
+    public static final String EXPECTED_ID_LIST = "1,2,3,4,5";
+
+    private MetapropertyQuery metapropertyQuery;
+
+    @Before
+    public void setUp() {
+        this.metapropertyQuery = new MetapropertyQuery();
+    }
+
+    @Test
+    public void initializeEmptyMetapropertyQuery() {
+        assertNull(metapropertyQuery.getType());
+        assertNull(metapropertyQuery.getCount());
+        assertNull(metapropertyQuery.getOptions());
+        assertNull(metapropertyQuery.getIds());
+    }
+
+    @Test
+    public void setValuesForMediaQuery() {
+        metapropertyQuery.setType(EXPECTED_MEDIA_TYPE);
+        assertEquals(EXPECTED_MEDIA_TYPE, metapropertyQuery.getType());
+
+        metapropertyQuery.setCount(EXPECTED_BOOLEAN);
+        assertEquals(EXPECTED_BOOLEAN, metapropertyQuery.getCount());
+
+        metapropertyQuery.setOptions(EXPECTED_BOOLEAN);
+        assertEquals(EXPECTED_BOOLEAN, metapropertyQuery.getOptions());
+
+        metapropertyQuery.setIds(EXPECTED_ID_LIST);
+        assertEquals(EXPECTED_ID_LIST, metapropertyQuery.getIds());
+
+    }
+}


### PR DESCRIPTION
Implement Issue #107 - add properties "options" and "id" to class MetapropertiesQuery to support getting all metaproperties without options and retrieving individual metaproperties (with options if needed).

This is needed because getting al metadataproperties with options, as is the only possible way in the SDK, can result in an API timeout of very large number of options exist on some metaproperties (e.g. complex taxonomies).