### PR TITLE
Added uri property to UsageQuery

### DIFF
--- a/src/main/java/com/bynder/sdk/query/UsageQuery.java
+++ b/src/main/java/com/bynder/sdk/query/UsageQuery.java
@@ -19,12 +19,27 @@ public class UsageQuery {
     @ApiField(name = "asset_id")
     private String assetId;
 
+    /**
+     * Uri of the asset
+     */
+    @ApiField(name = "uri")
+    private String uri;
+
     public String getAssetId() {
         return assetId;
     }
 
     public UsageQuery setAssetId(final String assetId) {
         this.assetId = assetId;
+        return this;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public UsageQuery setUri(final String uri) {
+        this.uri = uri;
         return this;
     }
 }


### PR DESCRIPTION
Hi guys,

I added the uri property to the UsageQuery class, as described in the documentation: 
https://bynder.docs.apiary.io/#reference/asset-usage/asset-usage-operations/retrieve-asset-usage

This enables clients to also be able to query asset usages on the uri, instead of only on the asset id.

It would be great if this can be merged, thanks in advance!

Regards, Philippe