### PR TITLE
Support for Custom Metaproperties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/src/main/java/com/bynder/sdk/api/ApiFactory.java
+++ b/src/main/java/com/bynder/sdk/api/ApiFactory.java
@@ -6,14 +6,21 @@
  */
 package com.bynder.sdk.api;
 
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 import com.bynder.sdk.configuration.Configuration;
 import com.bynder.sdk.configuration.HttpConnectionSettings;
 import com.bynder.sdk.exception.BynderRuntimeException;
+import com.bynder.sdk.model.Media;
 import com.bynder.sdk.service.BynderClient;
 import com.bynder.sdk.util.BooleanTypeAdapter;
+import com.bynder.sdk.util.MediaTypeAdapter;
 import com.bynder.sdk.util.StringConverterFactory;
 import com.bynder.sdk.util.Utils;
 import com.google.gson.GsonBuilder;
+
 import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClient.Builder;
 import okhttp3.Request;
@@ -21,10 +28,6 @@ import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
-
-import java.io.IOException;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Factory to create API clients.
@@ -51,6 +54,7 @@ public class ApiFactory {
                 .addConverterFactory(GsonConverterFactory.create(
                         new GsonBuilder()
                                 .registerTypeAdapter(Boolean.class, new BooleanTypeAdapter())
+                                .registerTypeAdapter(Media.class, new MediaTypeAdapter())
                                 .create())
                 )
                 .client(createOkHttpClient(configuration))

--- a/src/main/java/com/bynder/sdk/model/Media.java
+++ b/src/main/java/com/bynder/sdk/model/Media.java
@@ -120,6 +120,11 @@ public class Media {
      * versions equal to true.
      */
     private List<MediaItem> mediaItems;
+    /**
+     * Custom properties not having an PropertyOption. Key is the property name and
+     * value the value(s) of that property.
+     */
+    private Map<String, List<String>> customMetaproperties;
 
     public String getId() {
         return id;
@@ -215,5 +220,9 @@ public class Media {
 
     public List<MediaItem> getMediaItems() {
         return mediaItems;
+    }
+
+    public Map<String, List<String>> getCustomMetaproperties() {
+        return customMetaproperties;
     }
 }

--- a/src/main/java/com/bynder/sdk/util/MediaTypeAdapter.java
+++ b/src/main/java/com/bynder/sdk/util/MediaTypeAdapter.java
@@ -1,0 +1,66 @@
+package com.bynder.sdk.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.bynder.sdk.model.Media;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+public class MediaTypeAdapter implements JsonDeserializer<Media> {
+
+    private static final String PROPERTY_PREFIX = "property_";
+    private static final String CUSTOM_METAPROPERTY_FIELDNAME = "customMetaproperties";
+
+    private final Gson gson;
+
+    public MediaTypeAdapter() {
+        this.gson = new GsonBuilder().registerTypeAdapter(Boolean.class, new BooleanTypeAdapter()).create();
+    }
+
+    @Override
+    public Media deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject jsonObject = json.getAsJsonObject();
+        Media media = gson.fromJson(jsonObject, Media.class);
+
+        Map<String, List<String>> metaproperties = new LinkedHashMap<>();
+
+        for (Map.Entry<String, JsonElement> elementJson : jsonObject.entrySet()) {
+            if (elementJson.getKey().startsWith(PROPERTY_PREFIX)) {
+                String propertyName = elementJson.getKey().substring(PROPERTY_PREFIX.length());
+                List<String> values = metaproperties.getOrDefault(metaproperties, new ArrayList<>());
+                if (elementJson.getValue().isJsonArray()) {
+                    for (JsonElement element : elementJson.getValue().getAsJsonArray()) {
+                        values.add(element.getAsString());
+                    }
+                } else {
+                    values.add(elementJson.getValue().getAsString());
+                }
+                metaproperties.put(propertyName, values);
+            }
+        }
+        setMetaproperties(media, metaproperties);
+        return media;
+    }
+
+    private void setMetaproperties(Media media, Map<String, List<String>> metaproperties) {
+        try {
+            Field metapropertiesField = media.getClass().getDeclaredField(CUSTOM_METAPROPERTY_FIELDNAME);
+            metapropertiesField.setAccessible(true);
+            metapropertiesField.set(media, metaproperties);
+        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
+            // does not occur unless Media class is changed
+        }
+    }
+
+}

--- a/src/test/java/com/bynder/sdk/api/ApiFactoryTest.java
+++ b/src/test/java/com/bynder/sdk/api/ApiFactoryTest.java
@@ -34,7 +34,7 @@ public class ApiFactoryTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.when(configuration.getBaseUrl()).thenReturn(new URL(BASE_URL));
         Mockito.when(configuration.getHttpConnectionSettings())
             .thenReturn(new HttpConnectionSettings());

--- a/src/test/java/com/bynder/sdk/configuration/ConfigurationTest.java
+++ b/src/test/java/com/bynder/sdk/configuration/ConfigurationTest.java
@@ -35,7 +35,7 @@ public class ConfigurationTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/com/bynder/sdk/configuration/HttpConnectionSettingsTest.java
+++ b/src/test/java/com/bynder/sdk/configuration/HttpConnectionSettingsTest.java
@@ -40,7 +40,7 @@ public class HttpConnectionSettingsTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/com/bynder/sdk/service/BynderClientTest.java
+++ b/src/test/java/com/bynder/sdk/service/BynderClientTest.java
@@ -34,7 +34,7 @@ public class BynderClientTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.when(configuration.getBaseUrl()).thenReturn(new URL(BASE_URL));
         Mockito.when(configuration.getHttpConnectionSettings())
             .thenReturn(new HttpConnectionSettings());

--- a/src/test/java/com/bynder/sdk/service/asset/AssetServiceImplTest.java
+++ b/src/test/java/com/bynder/sdk/service/asset/AssetServiceImplTest.java
@@ -37,7 +37,7 @@ public class AssetServiceImplTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         assetService = AssetService.Builder.create(bynderApi, queryDecoder);
     }
 

--- a/src/test/java/com/bynder/sdk/service/collection/CollectionServiceImplTest.java
+++ b/src/test/java/com/bynder/sdk/service/collection/CollectionServiceImplTest.java
@@ -38,7 +38,7 @@ public class CollectionServiceImplTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         collectionService = CollectionService.Builder.create(bynderApi, queryDecoder);
     }
 

--- a/src/test/java/com/bynder/sdk/service/oauth/OAuthServiceImplTest.java
+++ b/src/test/java/com/bynder/sdk/service/oauth/OAuthServiceImplTest.java
@@ -61,7 +61,7 @@ public class OAuthServiceImplTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         when(oauthClient.getAccessToken(anyMap())).thenReturn(Observable.just(Response.success(token)));
         when(configuration.getBaseUrl()).thenReturn(new URL(EXPECTED_BASE_URL));
         when(configuration.getOAuthSettings()).thenReturn(oAuthSettings);

--- a/src/test/java/com/bynder/sdk/util/MediaTypeAdapterTest.java
+++ b/src/test/java/com/bynder/sdk/util/MediaTypeAdapterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017 Bynder B.V. All rights reserved.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license
+ * information.
+ *
+ * JUnit framework component copyright (c) 2002-2017 JUnit. All Rights Reserved. Licensed under
+ * Eclipse Public License - v 1.0. You may obtain a copy of the License at
+ * https://www.eclipse.org/legal/epl-v10.html.
+ */
+package com.bynder.sdk.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.bynder.sdk.model.Media;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests the {@link BooleanTypeAdapter} class methods.
+ */
+public class MediaTypeAdapterTest {
+    
+    
+    /**
+     * Given JSON
+     * 
+     * {
+     *   "id": "FF5DB884-5665-4127-88D0116D8EB379FE",
+     *   "isPublic": 0,
+     *   "property_Articlenumber": "16773",
+     *   "property_Language": [
+     *     "Neutral"
+     *   ]
+     * }
+     * 
+     */
+    private final String givenApiResponse = "{ \"id\": \"FF5DB884-5665-4127-88D0116D8EB379FE\", \"isPublic\": 0, \"property_Articlenumber\": \"16773\", \"property_Language\": [ \"Neutral\" ]}";
+
+
+    /**
+     * Tests that
+     * {@link MediaTypeAdapter#deserialize(com.google.gson.JsonElement, java.lang.reflect.Type, com.google.gson.JsonDeserializationContext)}
+     * correctly converts all "property_" prefixed json fields into a custom Map<String,List<String>> when deserializing the Json response returned by the
+     * API.
+     */
+    @Test
+    public void deserializeWithMediaTypeAdapter() {
+        MediaTypeAdapter mediaTypeAdapter = new MediaTypeAdapter();
+
+        Media actualMedia = mediaTypeAdapter.deserialize(JsonParser.parseString(givenApiResponse), null, null);
+       
+        // common default field like ID
+        assertEquals("FF5DB884-5665-4127-88D0116D8EB379FE", actualMedia.getId());
+        
+        // boolean using BooleanTypeAdapter inside MediaTypeAdapter
+        assertEquals(Boolean.FALSE, actualMedia.isPublic());
+        
+        // new custom "property_"  which is returned as string from API#
+        
+        assertNotNull(actualMedia.getCustomMetaproperties());
+        assertTrue(actualMedia.getCustomMetaproperties().containsKey("Articlenumber"));
+        assertEquals(Arrays.asList("16773"), actualMedia.getCustomMetaproperties().get("Articlenumber"));
+        
+        // new custom "property_" which is returned as array from API
+        assertNotNull(actualMedia.getCustomMetaproperties());
+        assertTrue(actualMedia.getCustomMetaproperties().containsKey("Language"));
+        assertEquals(Arrays.asList("Neutral"), actualMedia.getCustomMetaproperties().get("Language"));
+    }
+}

--- a/src/test/java/com/bynder/sdk/util/RXUtilsTest.java
+++ b/src/test/java/com/bynder/sdk/util/RXUtilsTest.java
@@ -1,23 +1,27 @@
 package com.bynder.sdk.util;
 
-import com.bynder.sdk.exception.HttpResponseException;
-import io.reactivex.Observable;
-import okhttp3.MediaType;
-import okhttp3.ResponseBody;
-import org.junit.Before;
-import org.junit.Test;
-import retrofit2.Response;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.bynder.sdk.exception.HttpResponseException;
+
+import io.reactivex.Observable;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
 
 public class RXUtilsTest {
 
@@ -93,10 +97,10 @@ public class RXUtilsTest {
     }
 
     @Test
-    public void readFile() throws IOException {
-        String path = ClassLoader.getSystemResource("config.properties").getPath();
+    public void readFile() throws IOException, URISyntaxException {
+        URI path = ClassLoader.getSystemResource("config.properties").toURI();
         byte[] expected = Files.readAllBytes(Paths.get(path));
-        byte[] actual = RXUtils.readFile(path).blockingGet();
+        byte[] actual = RXUtils.readFile(Paths.get(path).toString()).blockingGet();
         assertArrayEquals(expected, actual);
     }
 


### PR DESCRIPTION
I've create a PR for https://github.com/Bynder/bynder-java-sdk/issues/112.

In this PR the Media class now returns `customMetaproperties` as `Map<String, List<String>` where the key is the property name without `property_` prefix and the value is **always** a list of strings, even if the API returned a single String as value for that specific attribute. I did this for simlicity reasons.

The following API response as Media object
```javascript
  "property_Articlenumber": "4711",
  "property_Testattribute": [
      "Value"
  ],
  "property_Asset_Type": [
      "Photos"
  ]
``` 

will be presented in the Java Object as below

```javascript
"customMetaproperties": {
    "Articlenumber": [
        "4711"
    ],
    "Testattribute": [
        "Value"
    ],
    "Asset_Type": [
        "Photos"
    ]
}
```

Unfortunately the choice of Retrofit doesn't perfectly fit (pun not intended) to the choice of having "property_" prefixed attributes on the same level as all other Media attributes.
With Retrofit you're only capable of setting custom Adapters on the API delivered attributes like "isPublic" for example. If the delivered attribute is some kind of wildcard like "property_*" a custom adapter is not possible at all.
That's why i implemented a custom MediaTypeAdapter for the whole class as the only possible solution i could think of.

Please give some feedback on the implementation and let me know if this works fine to you. 
Testcases are included.