### PR TITLE
Fix failure to upload files: "Invalid import ID" from polling for status

### DIFF
--- a/src/main/java/com/bynder/sdk/query/upload/PollStatusQuery.java
+++ b/src/main/java/com/bynder/sdk/query/upload/PollStatusQuery.java
@@ -21,7 +21,10 @@ public class PollStatusQuery {
     private final String[] items;
 
     public PollStatusQuery(final String[] items) {
-        this.items = items;
+        this.items = new String[items.length];
+        for(int i = 0; i < items.length; i++) {
+            this.items[i] = items[i].replace("/", "");
+        }
     }
 
     public String[] getItems() {


### PR DESCRIPTION
This is a PR to hopefully solve the issue #123, of being unable to upload files to bynder due to an invalid import ID, that contains an extra / (slash) at the end of the import ID.